### PR TITLE
fix: fixed vda-account comp to sync to vda-login

### DIFF
--- a/components/account/src/helpers/VeridaHelper.ts
+++ b/components/account/src/helpers/VeridaHelper.ts
@@ -2,13 +2,15 @@
 import { EnvironmentType, Network } from "@verida/client-ts";
 import { EventEmitter } from "events";
 
-import { hasSession, VaultAccount } from "@verida/account-web-vault";
+import { VaultAccount, hasSession } from "@verida/account-web-vault";
 
 import { Profile, Connect } from "../interface";
+import store from "store";
 
 
 const VUE_APP_VAULT_CONTEXT_NAME = "Verida: Vault";
 
+export const VERIDA_SESSION = '_verida_auth_context';
 
 
 const VUE_APP_LOGO_URL =
@@ -20,6 +22,7 @@ class VeridaHelpers extends EventEmitter {
   private account: any;
   public did?: string;
   public connected?: boolean;
+  public vdaAccount?: boolean;
   public contextName?: string | any;
 
   constructor() {
@@ -73,21 +76,44 @@ class VeridaHelpers extends EventEmitter {
     await cb();
   }
 
-  autoLogin() {
-    return hasSession(this.contextName as string);
+  async syncVdaAccount() {
+    this.vdaAccount = true
+  }
+
+  async autoLogin(contextName: string) {
+    await this.connect({
+      contextName
+    })
+  }
+
+  hasSession(contextName: string): boolean {
+    return hasSession(contextName)
   }
 
   async logout(): Promise<void> {
-    await this.context.getAccount().disconnect(this.contextName);
-    this.context = null;
-    this.account = null;
-    this.connected = false;
-    this.profile = {
-      avatar: {},
-      name: "",
-      country: "",
+    const obj = store.get('_verida_auth_context')
+    let ct;
+    Object.keys(obj).map(ls => (
+      ct = ls
+    ))
+
+    console.log(ct);
+
+    if (!this.context && ct) {
+      await this.autoLogin(ct)
     }
-    this.did = "";
+
+    // await this.context.getAccount().disconnect(this.contextName);
+    // this.context = null;
+    // this.account = null;
+    // this.connected = false;
+    // this.profile = {
+    //   avatar: {},
+    //   name: "",
+    //   country: "",
+    // }
+    // this.did = "";
+    // this.vdaAccount = false
   }
 }
 

--- a/components/account/src/lib-components/vda-login.vue
+++ b/components/account/src/lib-components/vda-login.vue
@@ -62,12 +62,14 @@ export default /*#__PURE__*/ defineComponent({
       required: false,
     },
   },
-
   data() {
     return {
       isLoading: false,
       error: {},
     };
+  },
+  async beforeMount() {
+    await this.init();
   },
   methods: {
     async connect() {
@@ -94,6 +96,11 @@ export default /*#__PURE__*/ defineComponent({
       this.error = error;
       if (this.onError) {
         this.onError(this.error);
+      }
+    },
+    async init() {
+      if (VeridaHelper.hasSession(this.contextName)) {
+        await this.connect();
       }
     },
   },

--- a/components/verifiable-credential-display/src/vda-credentials-view.vue
+++ b/components/verifiable-credential-display/src/vda-credentials-view.vue
@@ -101,7 +101,7 @@ export default /*#__PURE__*/ defineComponent({
 .vda-vc-content-value {
   font-size: 0.9rem;
   line-height: 150%;
-  text-align: left;
+  text-align: left !important;
   color: #060520;
   display: block;
   margin: 0 0.5rem;


### PR DESCRIPTION
- Fixed vda-account comp to sync to vda-login

### Todos 

I added an event emitter to load the profile `vda-account` component whenever the `vda-login` is triggered
also the `vda-account` can handle login itself if the `vda-login` component is not been used in an application.
#46